### PR TITLE
Simplify and improve device detection (support subinterfaces)

### DIFF
--- a/packstack/installer/utils/network.py
+++ b/packstack/installer/utils/network.py
@@ -76,8 +76,7 @@ def force_ip(host, allow_localhost=False):
 
 def device_from_ip(ip):
     server = ScriptRunner()
-    server.append("DEVICE=$(ip address show to %s | head -n 1 |"
-                  " sed -e 's/.*: \(.*\):.*/\\1/g')" % ip)
+    server.append("DEVICE=$(ip -o address show to %s | cut -f 2 -d ' ')" % ip)
     # Test device, raises an exception if it doesn't exist
     server.append("ip link show \"$DEVICE\" > /dev/null")
     server.append("echo $DEVICE")


### PR DESCRIPTION
The current logic does not properly handle sub-interfaces like those used for VLAN tagging, due to the way ip displays these by default. This patch seems to to both simplify the logic here and fix this problem.
