### PR TITLE
- fix regex of nameserver

### DIFF
--- a/packstack/installer/utils/network.py
+++ b/packstack/installer/utils/network.py
@@ -15,7 +15,7 @@ def get_localhost_ip():
     #        address.
 
     # find nameservers
-    ns_regex = re.compile('nameserver\s*(?P<ns_ip>[\d\.\:])')
+    ns_regex = re.compile('nameserver\s*(?P<ns_ip>[\d\.\:]+)')
     rc, resolv = execute('cat /etc/resolv.conf | grep nameserver',
                          can_fail=False, use_shell=True, log=False)
     nsrvs = []


### PR DESCRIPTION
This change fix matching pattern of nameserver's address.
Current pattern matches to the only first char of IP address, so later reachability check always failed.
(But this error cause no problem with Internet reachability because of built-in nameserver's address "8.8.8.8")
