### PR TITLE
Fixed allowed host list for firewall

### DIFF
--- a/packstack/plugins/swift_600.py
+++ b/packstack/plugins/swift_600.py
@@ -252,7 +252,10 @@ def createstoragemanifest(config):
         # Allowed host list for firewall
         hosts = set()
         for host in config['CONFIG_SWIFT_STORAGE_HOSTS'].split(','):
-            hosts.add(host.strip())
+            host = host.strip()
+            if '/' in host:
+                host = host.split('/')[0]
+            hosts.add(host)
         for host in config['CONFIG_SWIFT_PROXY_HOSTS'].split(','):
             hosts.add(host.strip())
         for host in config['CONFIG_NOVA_COMPUTE_HOSTS'].split(','):


### PR DESCRIPTION
when CONFIG_SWIFT_STORAGE_HOSTS contains '/', for example,

CONFIG_SWIFT_STORAGE_HOSTS = 10.92.112.51/sdb1 , 

the allowed host list in 10.92.112.51_swift.pp will be wrong: 

$hosts = [ '10.92.112.51','10.92.112.51/sdb1' ]

The error generated when puppet apply:

Error: Parameter source failed on Firewall[001 swift storage and rsync incoming 10.92.112.51/sdb1]: Munging failed for value "10.92.112.51/sdb1" in class source: no address for 10.92.112.51/sdb1 at /var/tmp/packstack/7bde90cee85b43878bb547b24bc3b7e3/manifests/10.92.112.51_swift.pp:94
Wrapped exception:
Munging failed for value "10.92.112.51/sdb1" in class source: no address for 10.92.112.51/sdb1 
