### PR TITLE
fix for lvm-backed swift device

### DIFF
--- a/packstack/installer/utils/shortcuts.py
+++ b/packstack/installer/utils/shortcuts.py
@@ -46,6 +46,10 @@ def split_hosts(hosts_string):
     hosts = set()
     for host in hosts_string.split(','):
         shost = host.strip()
+        # for lvm backed device (in the form of /dev/mapper/<vg>-<lv> or /dev/<vg>/<lv>)
+        # taken from https://github.com/harveyzh/packstack/commit/d2f8adfeaabb874ab36dd50bc6a016c1fff389db
+        if '/' in shost:
+            shost = shost.split('/')[0]
         if shost:
             hosts.add(shost)
     return hosts


### PR DESCRIPTION
Defining a logical volume as CONFIG_SWIFT_STORAGE_HOSTS=<IP_ADDRESS>/mapper/<LV> doesn't work.
Here is a port of the fix proposed by @harveyzh at https://github.com/harveyzh/packstack/commit/d2f8adfeaabb874ab36dd50bc6a016c1fff389db.
