### PR TITLE
Handle interface names containing "." or "-"

### DIFF
--- a/packstack/puppet/templates/neutron_ovs_agent_gre.pp
+++ b/packstack/puppet/templates/neutron_ovs_agent_gre.pp
@@ -1,5 +1,5 @@
 if "%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s" {
-  $localip = $ipaddress_%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s
+  $localip = getvar(regsubst("$ipaddress_%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s", '[.-]', '_', 'G'))
 } else {
   $localip = '%(CONFIG_NEUTRON_OVS_HOST)s'
 }

--- a/packstack/puppet/templates/neutron_ovs_agent_vxlan.pp
+++ b/packstack/puppet/templates/neutron_ovs_agent_vxlan.pp
@@ -1,6 +1,6 @@
 
 if "%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s" {
-  $localip = $ipaddress_%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s
+  $localip = getvar(regsubst("$ipaddress_%(CONFIG_NEUTRON_OVS_TUNNEL_IF)s", '[.-]', '_', 'G'))
 } else {
   $localip = '%(CONFIG_NEUTRON_OVS_HOST)s'
 }


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1057938 for
packstack by calling regsubst() to replace "." or "-" with "_" in interface
names when looking up ipaddress_\* facts.

(Update for "-" based on comment in https://github.com/redhat-openstack/astapor/pull/111).
