### PR TITLE
Add configuration for Qpid Dispatch router.

### DIFF
--- a/packstack/puppet/templates/qpid_dispatch.pp
+++ b/packstack/puppet/templates/qpid_dispatch.pp
@@ -1,0 +1,22 @@
+# See the qdrouterd.conf (5) manual page for information about this
+# file's format and options.
+
+container {
+    worker-threads: $container_worker_threads
+    container-name: $container_name
+}
+
+ssl-profile {
+    name: $ssl_profile_name
+}
+
+listener {
+    addr: $listen_address
+    port: listen_$port
+    sasl-mechanisms: $sasl_mechanisms
+}
+
+router {
+    mode: $router_mode
+    router-id: $router_id
+}


### PR DESCRIPTION
qdrouterd.conf should exist in /etc/qpid-dispatch/

Configurable options are:

  $container_worker_threads : the number of threads used by Dispatch
  $container_name:          : the name for the container
  $ssl_profile_name         : the SSL profile name to use
  $listener_address         : the interface name and port for incoming
                            : connections
  $listener_port            :
  $sasl_mechanisms          : the list of SASL mechanisms to use
  $router_mode              : either "standalone" or "interior"
  $router_id                : the router name
