### PR TITLE
update puppet stdlib to v8.1.0 due to URI.escape issues

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -154,7 +154,7 @@ mod 'ssh',
 
 mod 'stdlib',
   :git => 'https://github.com/puppetlabs/puppetlabs-stdlib',
-  :ref => 'v6.6.0'
+  :ref => 'v8.1.0'
 
 mod 'sysctl',
   :git => 'https://github.com/duritong/puppet-sysctl',


### PR DESCRIPTION
On RHEL 9.2 getting the following error due to the stdlib uriescape function

```
ERROR : Error appeared during Puppet run: 172.17.180.141_compute.pp
Error: Evaluation Error: Error while evaluating a Function Call, undefined method `escape' for URI:Module (file: /var/tmp/packstack/ef2f831f27894fe584a378a126bd043a/modules/nova/manifests/migration/libvirt.pp, line: 201, column: 49) on node undercloud01
```

Updating to stdlib v8.1.0 resolves the issue.